### PR TITLE
Allow synchronous processing

### DIFF
--- a/lib/KMeansEngine.js
+++ b/lib/KMeansEngine.js
@@ -191,7 +191,11 @@ class KMeansEngine {
       }
     }
 
-    return iterate();
+    if (self.asynchronous) {
+      return process.nextTick(iterate);
+    } else {
+      return iterate();
+    }
   }
 }
 

--- a/lib/KMeansEngine.js
+++ b/lib/KMeansEngine.js
@@ -10,7 +10,7 @@ class KMeansEngine {
     this.debug = this.options.debug || false;
     this.maxIterations = this.options.maxIterations;
     this.initialCentroids = this.options.initialCentroids;
-    this.asynchronous = this.options.asynchronous || true;
+    this.synchronous = this.options.synchronous || false;
     this.callback = callback;
 
     this.validateInput();
@@ -121,7 +121,6 @@ class KMeansEngine {
 
   clusterize() {
     const self = this;
-
     function iterate() {
       self.showLog(`Iteration ${self.iterations} started...`);
 
@@ -177,24 +176,33 @@ class KMeansEngine {
       if (!hasMoved) {
         self.showLog('Iteration done as all centroids have not moved');
 
-        return self.callback(null, self.getResult());
+        if (self.synchronous) {
+          return self.getResult();
+        } else {
+          return self.callback(null, self.getResult());
+        }
+
       } else if (self.maxIterations && self.iterations >= self.maxIterations) {
         self.showLog('Max iterations has been reached. Stop further iterations');
 
-        return self.callback(null, self.getResult());
+        if (self.synchronous) {
+          return self.getResult();
+        } else {
+          return self.callback(null, self.getResult());
+        }
       }
 
-      if (self.asynchronous) {
-        return process.nextTick(iterate);
-      } else {
+      if (self.synchronous) {
         return iterate();
+      } else {
+        return process.nextTick(iterate);
       }
     }
 
-    if (self.asynchronous) {
-      return process.nextTick(iterate);
-    } else {
+    if (self.synchronous) {
       return iterate();
+    } else {
+      return process.nextTick(iterate);
     }
   }
 }

--- a/lib/KMeansEngine.js
+++ b/lib/KMeansEngine.js
@@ -10,7 +10,7 @@ class KMeansEngine {
     this.debug = this.options.debug || false;
     this.maxIterations = this.options.maxIterations;
     this.initialCentroids = this.options.initialCentroids;
-    this.synchronous = this.options.synchronous || false;
+    this.synchronous = this.options.synchronous;
     this.callback = callback;
 
     this.validateInput();
@@ -57,6 +57,15 @@ class KMeansEngine {
           }
         }
       }
+    }
+
+    if (this.synchronous !== undefined && !_.isBoolean(this.synchronous)) {
+      throw new Error('Synchronous should be a boolean');
+    }
+
+    if ((this.callback !== undefined) &&
+        (!_.isFunction(this.callback) || this.synchronous)) {
+      throw new Error('Callback should be a function, only specified when Synchronous is true');
     }
   }
 

--- a/lib/KMeansEngine.js
+++ b/lib/KMeansEngine.js
@@ -65,7 +65,7 @@ class KMeansEngine {
 
     if ((this.callback !== undefined) &&
         (!_.isFunction(this.callback) || this.synchronous)) {
-      throw new Error('Callback should be a function, only specified when Synchronous is true');
+      throw new Error('Callback should be a function, only specified when Synchronous is false');
     }
   }
 

--- a/lib/KMeansEngine.js
+++ b/lib/KMeansEngine.js
@@ -10,6 +10,7 @@ class KMeansEngine {
     this.debug = this.options.debug || false;
     this.maxIterations = this.options.maxIterations;
     this.initialCentroids = this.options.initialCentroids;
+    this.asynchronous = this.options.asynchronous || true;
     this.callback = callback;
 
     this.validateInput();
@@ -183,7 +184,11 @@ class KMeansEngine {
         return self.callback(null, self.getResult());
       }
 
-      return process.nextTick(iterate);
+      if (self.asynchronous) {
+        return process.nextTick(iterate);
+      } else {
+        return iterate();
+      }
     }
 
     return iterate();

--- a/test/KMeansEngine.js
+++ b/test/KMeansEngine.js
@@ -175,7 +175,7 @@ describe('KMeansEngine', () => {
 
     it('should work asynchronously when specified explicitly', (done) => {
       var flag = false;
-      kmeans.clusterize(set2, { k: 3, maxIterations: 1, asynchronous: true }, () => {
+      kmeans.clusterize(set2, { k: 3, maxIterations: 1, synchronous: false }, () => {
         flag.should.be.equal(true);
 
         done();
@@ -186,13 +186,18 @@ describe('KMeansEngine', () => {
 
     it('should work synchronously when specified explicitly', (done) => {
       var flag = false;
-      kmeans.clusterize(set2, { k: 3, maxIterations: 12, asynchronous: false }, () => {
-        flag.should.be.equal(false);
+      const res = kmeans.clusterize(set2, { k: 3, maxIterations: 1, synchronous: true });
+      res.should.to.have.property('iterations');
+        res.should.to.have.property('clusters');
 
+        res.clusters.should.to.have.lengthOf(3);
+        res.clusters.forEach((cluster) => {
+          cluster.should.to.have.property('centroid');
+          cluster.should.to.have.property('vectorIds');
+        });
+
+        res.iterations.should.to.be.equal(1);
         done();
-      });
-      flag = true;
-
     });
   });
 });

--- a/test/KMeansEngine.js
+++ b/test/KMeansEngine.js
@@ -161,5 +161,38 @@ describe('KMeansEngine', () => {
         });
       });
     });
+
+    it('should work asynchronously by default', (done) => {
+      var flag = false;
+      kmeans.clusterize(set2, { k: 3, maxIterations: 1 }, () => {
+        flag.should.be.equal(true);
+
+        done();
+      });
+      flag = true;
+
+    });
+
+    it('should work asynchronously when specified explicitly', (done) => {
+      var flag = false;
+      kmeans.clusterize(set2, { k: 3, maxIterations: 1, asynchronous: true }, () => {
+        flag.should.be.equal(true);
+
+        done();
+      });
+      flag = true;
+
+    });
+
+    it('should work synchronously when specified explicitly', (done) => {
+      var flag = false;
+      kmeans.clusterize(set2, { k: 3, maxIterations: 12, asynchronous: false }, () => {
+        flag.should.be.equal(false);
+
+        done();
+      });
+      flag = true;
+
+    });
   });
 });

--- a/test/KMeansEngine.js
+++ b/test/KMeansEngine.js
@@ -48,6 +48,24 @@ describe('KMeansEngine', () => {
       }).should.to.throw('Max iterations should be a positive integer');
     });
 
+    it('should only accept synchronous as a boolean', () => {
+      (() => {
+        kmeans.clusterize(set1, { k: 3, synchronous: -1 }, () => {});
+      }).should.to.throw('Synchronous should be a boolean');
+    });
+
+    it('should only accept callback when called synchronously', () => {
+      (() => {
+        kmeans.clusterize(set1, { k: 3, synchronous: true }, () => {});
+      }).should.to.throw('Callback should be a function, only specified when Synchronous is true');
+    });
+
+    it('should only accept callback as a function', () => {
+      (() => {
+        kmeans.clusterize(set1, { k: 3},5);
+      }).should.to.throw('Callback should be a function, only specified when Synchronous is true');
+    });
+
     it('should only accept initial centroids as array of objects', () => {
       (() => {
         kmeans.clusterize(set1, { k: 2, initialCentroids: {} }, () => {});

--- a/test/KMeansEngine.js
+++ b/test/KMeansEngine.js
@@ -57,13 +57,13 @@ describe('KMeansEngine', () => {
     it('should only accept callback when called synchronously', () => {
       (() => {
         kmeans.clusterize(set1, { k: 3, synchronous: true }, () => {});
-      }).should.to.throw('Callback should be a function, only specified when Synchronous is true');
+      }).should.to.throw('Callback should be a function, only specified when Synchronous is false');
     });
 
     it('should only accept callback as a function', () => {
       (() => {
         kmeans.clusterize(set1, { k: 3},5);
-      }).should.to.throw('Callback should be a function, only specified when Synchronous is true');
+      }).should.to.throw('Callback should be a function, only specified when Synchronous is false');
     });
 
     it('should only accept initial centroids as array of objects', () => {


### PR DESCRIPTION
Since there's no asynchronous dependencies (yet!), there's the potential to call clusterize() synchronously. This PR makes the necessary (small) changes to allow that as an option.

Added some tests around this, in particular the unnecessary callback parameter.